### PR TITLE
Supported Xcode custom keys for bundle identifier

### DIFF
--- a/lib/deploygate/xcode/analyze.rb
+++ b/lib/deploygate/xcode/analyze.rb
@@ -77,13 +77,22 @@ module DeployGate
           # $(PRODUCT_NAME) or ${PRODUCT_NAME}
           if match = id.match(/\$\((.+)\)|\${(.+)}/)
             custom_id = match[1] || match[2]
-            target_build_configration.build_settings[custom_id]
+            if custom_id == 'TARGET_NAME'
+              target_project_setting.name
+            else
+              target_build_configration.build_settings[custom_id]
+            end
           else
             id
           end
         end
 
-        ids.join('.')
+        new_bundle_identifier = ids.join('.')
+        if new_bundle_identifier.match(/\$\((.+)\)|\${(.+)}/)
+          convert_bundle_identifier(new_bundle_identifier)
+        else
+          new_bundle_identifier
+        end
       end
 
       # @return [String]

--- a/lib/deploygate/xcode/analyze.rb
+++ b/lib/deploygate/xcode/analyze.rb
@@ -72,14 +72,18 @@ module DeployGate
       # @param [String] bundle_identifier
       # @return [String]
       def convert_bundle_identifier(bundle_identifier)
-        identifier = bundle_identifier
-        if match = bundle_identifier.match(/\$\((.+)\)/)
-          custom_id = match[1]
-          identifier = target_build_configration.build_settings[custom_id]
+        ids = bundle_identifier.split('.')
+        ids = ids.map do |id|
+          # $(PRODUCT_NAME) or ${PRODUCT_NAME}
+          if match = id.match(/\$\((.+)\)|\${(.+)}/)
+            custom_id = match[1] || match[2]
+            target_build_configration.build_settings[custom_id]
+          else
+            id
+          end
         end
-        identifier = convert_bundle_identifier(identifier) if bundle_identifier.match(/\$\((.+)\)/)
 
-        identifier
+        ids.join('.')
       end
 
       # @return [String]

--- a/lib/deploygate/xcode/analyze.rb
+++ b/lib/deploygate/xcode/analyze.rb
@@ -72,27 +72,18 @@ module DeployGate
       # @param [String] bundle_identifier
       # @return [String]
       def convert_bundle_identifier(bundle_identifier)
-        ids = bundle_identifier.split('.')
-        ids = ids.map do |id|
-          # $(PRODUCT_NAME) or ${PRODUCT_NAME}
-          if match = id.match(/\$\((.+)\)|\${(.+)}/)
-            custom_id = match[1] || match[2]
-            if custom_id == 'TARGET_NAME'
-              target_project_setting.name
-            else
-              target_build_configration.build_settings[custom_id]
-            end
+        new_bundle_identifier = bundle_identifier.gsub(/\$\(([^\)]+)\)|\${([^}]+)}/) {
+          custom_id = $1 || $2
+          if custom_id == 'TARGET_NAME'
+            target_project_setting.name
           else
-            id
+            target_build_configration.build_settings[custom_id]
           end
-        end
+        }
+        # bail out if the result identical to the original
+        return bundle_identifier if new_bundle_identifier == bundle_identifier
 
-        new_bundle_identifier = ids.join('.')
-        if new_bundle_identifier.match(/\$\((.+)\)|\${(.+)}/)
-          convert_bundle_identifier(new_bundle_identifier)
-        else
-          new_bundle_identifier
-        end
+        convert_bundle_identifier(new_bundle_identifier)
       end
 
       # @return [String]

--- a/spec/deploygate/xcode/analyze_spec.rb
+++ b/spec/deploygate/xcode/analyze_spec.rb
@@ -23,7 +23,10 @@ describe DeployGate::Xcode::Analyze do
       def build_settings
         {
             'PRODUCT_NAME' => '$(TARGET_NAME)',
-            'CUSTOM_KEY'   => 'CustomKey'
+            'CUSTOM_KEY'   => 'CustomKey',
+            'PRODUCT_BUNDLE_IDENTIFER' => 'com.deploygate.app',
+            'DEBUG_POSTFIX' => '.debug',
+            'LOOP' => '$(LOOP)'
         }
       end
     end
@@ -40,6 +43,16 @@ describe DeployGate::Xcode::Analyze do
     it do
       analyze = DeployGate::Xcode::Analyze.new('', nil, DummyProject::SCHEME)
       expect(analyze.convert_bundle_identifier('com.deploygate.$(PRODUCT_NAME).${CUSTOM_KEY}')).to eq 'com.deploygate.TargetName.CustomKey'
+    end
+
+    it 'if only env' do
+      analyze = DeployGate::Xcode::Analyze.new('', nil, DummyProject::SCHEME)
+      expect(analyze.convert_bundle_identifier('$(PRODUCT_BUNDLE_IDENTIFER)$(DEBUG_POSTFIX)')).to eq 'com.deploygate.app.debug'
+    end
+
+    it 'if loop env' do
+      analyze = DeployGate::Xcode::Analyze.new('', nil, DummyProject::SCHEME)
+      expect(analyze.convert_bundle_identifier('$(LOOP)')).to eq '$(LOOP)'
     end
   end
 

--- a/spec/deploygate/xcode/analyze_spec.rb
+++ b/spec/deploygate/xcode/analyze_spec.rb
@@ -1,3 +1,39 @@
 describe DeployGate::Xcode::Analyze do
-  # TODO: add test
+
+  context '#convert_bundle_identifier' do
+
+    class DummyProject
+      SCHEME = 'dummy'
+      def schemes
+        [SCHEME, 'dummy2']
+      end
+
+      def options
+        {}
+      end
+    end
+
+    class DummyBuildConfigration
+      def build_settings
+        {
+            'PRODUCT_NAME' => 'ProductName',
+            'CUSTOM_KEY'   => 'CustomKey'
+        }
+      end
+    end
+
+    before do
+      allow_any_instance_of(DeployGate::Xcode::Analyze).to receive(:find_scheme_workspace).and_return('')
+      allow_any_instance_of(DeployGate::Xcode::Analyze).to receive(:find_build_workspace)
+      allow_any_instance_of(DeployGate::Xcode::Analyze).to receive(:target_build_configration).and_return(DummyBuildConfigration.new)
+      allow(FastlaneCore::Configuration).to receive(:create)
+      allow(FastlaneCore::Project).to receive(:new).and_return(DummyProject.new)
+    end
+
+    it do
+      analyze = DeployGate::Xcode::Analyze.new('', nil, DummyProject::SCHEME)
+      expect(analyze.convert_bundle_identifier('com.deploygate.$(PRODUCT_NAME).${CUSTOM_KEY}')).to eq 'com.deploygate.ProductName.CustomKey'
+    end
+  end
+
 end

--- a/spec/deploygate/xcode/analyze_spec.rb
+++ b/spec/deploygate/xcode/analyze_spec.rb
@@ -13,10 +13,16 @@ describe DeployGate::Xcode::Analyze do
       end
     end
 
+    class DummyProjectSetting
+      def name
+        'TargetName'
+      end
+    end
+
     class DummyBuildConfigration
       def build_settings
         {
-            'PRODUCT_NAME' => 'ProductName',
+            'PRODUCT_NAME' => '$(TARGET_NAME)',
             'CUSTOM_KEY'   => 'CustomKey'
         }
       end
@@ -26,13 +32,14 @@ describe DeployGate::Xcode::Analyze do
       allow_any_instance_of(DeployGate::Xcode::Analyze).to receive(:find_scheme_workspace).and_return('')
       allow_any_instance_of(DeployGate::Xcode::Analyze).to receive(:find_build_workspace)
       allow_any_instance_of(DeployGate::Xcode::Analyze).to receive(:target_build_configration).and_return(DummyBuildConfigration.new)
+      allow_any_instance_of(DeployGate::Xcode::Analyze).to receive(:target_project_setting).and_return(DummyProjectSetting.new)
       allow(FastlaneCore::Configuration).to receive(:create)
       allow(FastlaneCore::Project).to receive(:new).and_return(DummyProject.new)
     end
 
     it do
       analyze = DeployGate::Xcode::Analyze.new('', nil, DummyProject::SCHEME)
-      expect(analyze.convert_bundle_identifier('com.deploygate.$(PRODUCT_NAME).${CUSTOM_KEY}')).to eq 'com.deploygate.ProductName.CustomKey'
+      expect(analyze.convert_bundle_identifier('com.deploygate.$(PRODUCT_NAME).${CUSTOM_KEY}')).to eq 'com.deploygate.TargetName.CustomKey'
     end
   end
 


### PR DESCRIPTION
Supported $(PRODUCT_NAME) or ${PRODUCT_NAME}, $(TARGET_NAME) in bundle identifier.

## Example

Bundle identifier on Xcode: `com.deploygate.$(PRODUCT_NAME)`
After convert to: `com.deploygate.ProductName`