### PR TITLE
[Pending] Added a script to install dg command as a standalone binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,31 @@ dg: A command-line interface for DeployGate
 
 ## Installation
 
-Install *dg* as a non-system standalone binary. (Recommended)
+*Recommended*
+
+Install *dg* as a non-system standalone binary.
 
 ```bash
 curl -sL 'https://github.com/DeployGate/deploygate-cli/blob/master/install.bash' | [DG_VERSION=...] bash
-# You can uninstall dg by running `cd ~/.dg && rm -fr .bundle vendor link Gemfile Gemfile.lock && rm /usr/local/bin/dg`
+# If you would like to uninstall dg, then please run
+# cd ~/.dg && rm -fr .bundle vendor link Gemfile Gemfile.lock && rm /usr/local/bin/dg`
 ```
 
-Or run `gem install deploygate` to install *dg*.
+Or use `bundler` to install dg locally like the following:
+
+```Gemfile
+# Edit your Gemfile
+
+gem 'deploygate'
+```
+
+And then, execute `bundle install` with a path option.
+
+```bash
+bundle install --path=vendor/bundle
+```
+
+NOTE: We do not recommend that you install dg globally if you are not familier with ruby gem stuff.. i.e. `gem install deploygate`, `bundler` w/o a path option.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -10,26 +10,18 @@ dg: A command-line interface for DeployGate
 *dg* runs with a minimal set of requirements.
 
 - Ruby 2.4+ (Depends on [Ruby Maintenance Branches](https://www.ruby-lang.org/en/downloads/branches/))
+- Bundler
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Install *dg* as a non-system standalone binary. (Recommended)
 
-```
-gem 'deploygate'
-```
-
-And then execute:
-
-```
-$ bundle
+```bash
+curl -sL 'https://github.com/DeployGate/deploygate-cli/blob/master/install.bash' | [DG_VERSION=...] bash
+# You can uninstall dg by running `cd ~/.dg && rm -fr .bundle vendor link Gemfile Gemfile.lock && rm /usr/local/bin/dg`
 ```
 
-Or install it yourself as:
-
-```
-$ gem install deploygate
-```
+Or run `gem install deploygate` to install *dg*.
 
 ## Usage
 

--- a/install.bash
+++ b/install.bash
@@ -47,7 +47,8 @@ echo "Checking requirements..."
 
 checking "Checking ruby..."
 
-if ! type "ruby" >/dev/null 2>&1; then
+# rbenv has ruby command but it's just a hub so `type` may detect false-positive.
+if ! ruby -v >/dev/null 2>&1; then
   abort 'ruby is not found'
   warn "ruby is required to install dg. Please make sure ruby is installed."
   exit 1
@@ -69,7 +70,8 @@ ok "ruby's version ($(ruby --version)) is enough."
 
 checking "Checking bundler..."
 
-if ! type "bundle" >/dev/null 2>&1; then
+# rbenv has bundle command but it's just a hub so `type` may detect false-positive.
+if ! bundle -v >/dev/null 2>&1; then
   abort "bundle is not found"
   warn "bundle command is required to install dg. Please run ${BOLD}gem install bundler${RESET} to install it."
   exit 1

--- a/install.bash
+++ b/install.bash
@@ -5,6 +5,7 @@ set -o pipefail
 
 export MIN_RUBY_VERSION="2.4.0"
 export DG_DIRECTORY="$HOME/.dg"
+export DG_BIN_DIRECTORY_NAME="link"
 
 readonly BOLD="$(tput bold)"
 readonly GREEN="$(tput setaf 2)"
@@ -40,7 +41,7 @@ pending() {
   echo -e "- [-] $*"
 }
 
-mkdir -p "${DG_DIRECTORY}/link"
+mkdir -p "${DG_DIRECTORY}/${DG_BIN_DIRECTORY_NAME}"
 
 # Change the working directory to know which ruby version being used in the deploygate's directory.
 pushd "${DG_DIRECTORY}" >/dev/null
@@ -51,13 +52,11 @@ checking "Checking ruby..."
 
 if ! type "ruby" >/dev/null 2>&1; then
   abort 'ruby is not found'
-  warn "ruby is required to install this command. Please make sure ruby is installed."
+  warn "ruby is required to install dg. Please make sure ruby is installed."
   exit 1
 fi
 
 ok "ruby is installed."
-
-readonly ruby_version="$(ruby -e 'puts RUBY_VERSION')"
 
 checking "Checking ruby's version..."
 
@@ -73,17 +72,17 @@ ok "ruby's version ($(ruby --version)) is enough."
 
 checking "Checking bundler..."
 
-if ! type "bundler" >/dev/null 2>&1; then
-  abort "bundler is not found"
-  warn "bundler is required to install this command. Please run ${BOLD}gem install bundler${RESET} to install bundle command"
+if ! type "bundle" >/dev/null 2>&1; then
+  abort "bundle is not found"
+  warn "bundle command is required to install dg. Please run ${BOLD}gem install bundler${RESET} to install it."
   exit 1
 fi
 
-ok "bundler ($(bundler --version)) is installed"
+ok "bundler ($(bundler --version)) is installed."
 
 cat<<EOF
 
-This script will install dg to ${DG_DIRECTORY}/link ...
+This script will install dg to ${DG_DIRECTORY}/${DG_BIN_DIRECTORY_NAME} ...
 
 EOF
 
@@ -95,7 +94,7 @@ if ([ -L '/usr/local/bin/dg' ] || [ -f '/usr/local/bin/dg' ]) && [ ! -f 'Gemfile
   exit 1
 fi
 
-if [ -f 'link/dg' ]; then
+if [ -f "${DG_BIN_DIRECTORY_NAME}/dg" ]; then
   pending 'it sounds dg has already been installed.'
   read -p "Would you like to upgrade dg to the newer version or install dg under the new ruby version? (y/N): " yn
 
@@ -120,30 +119,30 @@ EOF
 
 sleep 1s
 
+readonly ruby_version="$(ruby -e 'puts RUBY_VERSION')"
 readonly ruby_abi=$(echo $ruby_version | cut -d. -f1-2).0
 
-if [ -f 'link/dg' ] && [ -d "vendor/bundle/ruby/$ruby_abi" ]; then
-  bundle upgrade deploygate
-else
-  if [ ! -f "Gemfile" ]; then
-    bundle init
-    echo >> Gemfile; echo "gem 'deploygate'" >> Gemfile
-  fi
+if [ ! -f "Gemfile" ]; then
+  bundle init
+  echo >> Gemfile; echo "gem 'deploygate'" >> Gemfile
+fi
 
-  # NOTE: this option is available since bundler 2.x
-  bundle config --local global_path_appends_ruby_scope true >/dev/null
-  bundle config --local disable_shared_gems true >/dev/null
+# NOTE: this option is available since bundler 2.x
+bundle config --local global_path_appends_ruby_scope true >/dev/null
+bundle config --local disable_shared_gems true >/dev/null
 
-  bundle install --jobs=4 --clean --retry 3 --path=vendor/bundle
+bundle check || bundle install --jobs=4 --clean --retry 3 --path=vendor/bundle
+bundle update deploygate
 
-  cat<<EOS > link/dg
+cat<<EOS > "${DG_BIN_DIRECTORY_NAME}/dg"
 #!/usr/bin/env bash
 
 set -eu
+set -o pipefail
 
-if ! \$(ruby -e "exit 1 unless RUBY_VERSION == '$ruby_version')"); then
+if \$(ruby -e "exit 1 unless RUBY_VERSION == '$ruby_version')"); then
   echo 'dg has been installed to $ruby_version but not to \$(ruby --version)' 1>&2
-  echo 'Please run "cd $DG_DIRECTORY && bundle install" to install dg into the current ruby version' 1>&2
+  echo 'Please run "cd $DG_DIRECTORY && bundle install" manually to re-install dg into the current ruby version' 1>&2
   exit 1
 fi
 
@@ -159,11 +158,11 @@ export BUNDLE_GLOBAL_PATH_APPENDS_RUBY_SCOPE=true
 exec bundle exec dg "\$@"
 EOS
 
-  chmod +x link/dg
-  ln -sf "${DG_DIRECTORY}/link/dg" /usr/local/bin/dg
+chmod +x "${DG_BIN_DIRECTORY_NAME}/dg"
+ln -sf "${DG_DIRECTORY}/${DG_BIN_DIRECTORY_NAME}/dg" /usr/local/bin/dg
 
-  echo -e "${GREEN}Welcome to DeployGate!${RESET}"
-  cat <<'EOF'
+echo -e "${GREEN}Welcome to DeployGate!${RESET}"
+cat <<'EOF'
         _            _                       _
       | |          | |                     | |
     __| | ___  ___ | | ___ _   ,____   ___ | |_ ___

--- a/install.bash
+++ b/install.bash
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+export MIN_RUBY_VERSION="2.4.0"
+export DG_DIRECTORY="$HOME/.dg"
+
+readonly BOLD="$(tput bold)"
+readonly GREEN="$(tput setaf 2)"
+readonly RED="$(tput setaf 1)"
+readonly MAGENTA="$(tput setaf 5)"
+readonly RESET="$(tput sgr0)"
+readonly COFFEE="☕️"
+
+warn() {
+  echo -e "${RED}$*${RESET}" 1>&2
+}
+
+checking() {
+  echo -en "- [ ] $*\r"
+  sleep 1
+}
+
+ok() {
+  # enough length
+  echo -en "                              \r"
+  echo -e "- [${GREEN}\u2714${RESET}] $*"
+}
+
+abort() {
+  # enough length
+  echo -en "                              \r"
+  echo -e "- [${RED}\u2573${RESET}] $*"
+}
+
+pending() {
+  # enough length
+  echo -en "                              \r"
+  echo -e "- [-] $*"
+}
+
+mkdir -p "${DG_DIRECTORY}/link"
+
+# Change the working directory to know which ruby version being used in the deploygate's directory.
+pushd "${DG_DIRECTORY}" >/dev/null
+
+echo "Checking requirements..."
+
+checking "Checking ruby..."
+
+if ! type "ruby" >/dev/null 2>&1; then
+  abort 'ruby is not found'
+  warn "ruby is required to install this command. Please make sure ruby is installed."
+  exit 1
+fi
+
+ok "ruby is installed."
+
+readonly ruby_version="$(ruby -e 'puts RUBY_VERSION')"
+
+checking "Checking ruby's version..."
+
+if ! $(ruby -e "exit 1 unless RUBY_VERSION >= ENV.fetch('MIN_RUBY_VERSION')"); then
+  abort "ruby's version is not enough"
+  warn "$(ruby --version) is currently running but it has not been supported."
+  warn "Please upgrade ruby to ${MIN_RUBY_VERSION} or over."
+
+  exit 1
+fi
+
+ok "ruby's version ($(ruby --version)) is enough."
+
+checking "Checking bundler..."
+
+if ! type "bundler" >/dev/null 2>&1; then
+  abort "bundler is not found"
+  warn "bundler is required to install this command. Please run ${BOLD}gem install bundler${RESET} to install bundle command"
+  exit 1
+fi
+
+ok "bundler ($(bundler --version)) is installed"
+
+cat<<EOF
+
+This script will install dg to ${DG_DIRECTORY}/link ...
+
+EOF
+
+checking "Checking the existing files..."
+
+if ([ -L '/usr/local/bin/dg' ] || [ -f '/usr/local/bin/dg' ]) && [ ! -f 'Gemfile.lock' ]; then
+  abort '/usr/local/bin/dg is found but not managed by this script.'
+  warn 'It sounds you have installed dg command by another way. Please uninstall the currently installed version to proceed.'
+  exit 1
+fi
+
+if [ -f 'link/dg' ]; then
+  pending 'it sounds dg has already been installed.'
+  read -p "Would you like to upgrade dg to the newer version or install dg under the new ruby version? (y/N): " yn
+
+  case "$yn" in
+    [yY]*)
+      ok 'dg has been installed and will be manipulated'
+      ;;
+    *)
+      warn "Canceled."
+      exit 1
+      ;;
+  esac
+else
+  ok 'dg has not been installed yet'
+fi
+
+cat<<EOF
+Installing ${BOLD}dg${RESET}.
+${BOLD}This may take a while.${RESET} It's a good time to grab some coffee ${COFFEE}
+
+EOF
+
+sleep 1s
+
+readonly ruby_abi=$(echo $ruby_version | cut -d. -f1-2).0
+
+if [ -f 'link/dg' ] && [ -d "vendor/bundle/ruby/$ruby_abi" ]; then
+  bundle upgrade deploygate
+else
+  if [ ! -f "Gemfile" ]; then
+    bundle init
+    echo >> Gemfile; echo "gem 'deploygate'" >> Gemfile
+  fi
+
+  # NOTE: this option is available since bundler 2.x
+  bundle config --local global_path_appends_ruby_scope true >/dev/null
+  bundle config --local disable_shared_gems true >/dev/null
+
+  bundle install --jobs=4 --clean --retry 3 --path=vendor/bundle
+
+  cat<<EOS > link/dg
+#!/usr/bin/env bash
+
+set -eu
+
+if ! \$(ruby -e "exit 1 unless RUBY_VERSION == '$ruby_version')"); then
+  echo 'dg has been installed to $ruby_version but not to \$(ruby --version)' 1>&2
+  echo 'Please run "cd $DG_DIRECTORY && bundle install" to install dg into the current ruby version' 1>&2
+  exit 1
+fi
+
+if (($(bundle --version | awk '\$0=\$3' | cut -d. -f1) < 2)); then
+  export BUNDLE_PATH="$DG_DIRECTORY/vendor/bundle/ruby/$ruby_abi"
+else
+  export BUNDLE_PATH="$DG_DIRECTORY/vendor/bundle"
+fi
+
+export BUNDLE_GEMFILE="$DG_DIRECTORY/Gemfile"
+export BUNDLE_GLOBAL_PATH_APPENDS_RUBY_SCOPE=true
+
+exec bundle exec dg "\$@"
+EOS
+
+  chmod +x link/dg
+  ln -sf "${DG_DIRECTORY}/link/dg" /usr/local/bin/dg
+
+  echo -e "${GREEN}Welcome to DeployGate!${RESET}"
+  cat <<'EOF'
+        _            _                       _
+      | |          | |                     | |
+    __| | ___  ___ | | ___ _   ,____   ___ | |_ ___
+    / _` |/ _ \' _ \| |/ _ \ \ / / _ \ / _ `| __/ _ \
+  | (_| |  __/ |_) | | (_) \ v / (_| | (_| | |_' __/
+    \___, \___| .__/|_|\___/ ` / \__, |\__,_|\__\___`
+              |_|           /_/  |___/
+
+EOF
+fi


### PR DESCRIPTION
Installing locally with `bundler` is no problem but *global* install with `bundler` or just `gem` causes a conflict around fastlane in fact.
This script allows to install `dg` into `~/.dg`, so it's not global, and to use `dg` seemlessly through a custom binstub.

The rough flow

- Run `cd ~/.dg`
- Run `bundle install --path vendor/bundle`
- Create a custom binstub which runs `bundle exec dg` as `~/.dg/link/dg`
- Create a symlink `/usr/local/bin/dg` -> ~/.dg/link/dg