### PR TITLE
Disable help_pager

### DIFF
--- a/lib/deploygate/command_builder.rb
+++ b/lib/deploygate/command_builder.rb
@@ -40,6 +40,7 @@ module DeployGate
     def run
       setup()
 
+      program :help_paging, false
       program :name, I18n.t('command_builder.name')
       program :version,  VERSION
       program :description, I18n.t('command_builder.description')


### PR DESCRIPTION
I can't see help without the less command.

```
root@8287b91129e2:/usr/src/deploygate/webfront# dg --help
/bin/sh: 1: less: not found
```

https://github.com/commander-rb/commander/issues/58