### PR TITLE
Relax bundler requirement to allow 2.x

### DIFF
--- a/deploygate.gemspec
+++ b/deploygate.gemspec
@@ -40,7 +40,7 @@ POST_INSTALL_MESSAGE
   # ios build
   spec.add_runtime_dependency 'fastlane', '~> 2.115'
 
-  spec.add_development_dependency 'bundler', '~> 1.17'
+  spec.add_development_dependency 'bundler', '>= 1.17', '< 3.0'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.5'
   spec.add_development_dependency 'webmock', '~> 2.3'


### PR DESCRIPTION
bundler version 2 is available.

```
$ gem i bundler
Fetching: bundler-2.1.1.gem (100%)
Successfully installed bundler-2.1.1
1 gem installed
```