### PR TITLE
Fix warn of json with ruby-2.7 

### DIFF
--- a/deploygate.gemspec
+++ b/deploygate.gemspec
@@ -20,7 +20,7 @@ dg installed! To get started fast:
 
 POST_INSTALL_MESSAGE
 
-  spec.add_runtime_dependency 'json', '~> 1.8'
+  spec.add_runtime_dependency 'json', '~> 2.0'
   spec.add_runtime_dependency 'httpclient', '~> 2.8'
   spec.add_runtime_dependency 'commander', '~> 4.4'
   spec.add_runtime_dependency 'plist', '~> 3.1'


### PR DESCRIPTION
```ruby
# Gemfile
if ENV["USE_LOCAL"] == '1'
  gem "deploygate", path: '/Users/koji/src/deploygate-cli'
else
  gem "deploygate"
end
```

```
$ ruby -v
ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin18]
```

## before
```shell
$ USE_LOCAL=0 bundle exec dg deploy deploygate-sample.ipa
/Users/koji/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/faraday_middleware-0.13.1/lib/faraday_middleware/response_middleware.rb:14: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/Users/koji/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/json-1.8.6/lib/json/common.rb:155: warning: Using the last argument as keyword parameters is deprecated
/Users/koji/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/json-1.8.6/lib/json/common.rb:155: warning: Using the last argument as keyword parameters is deprecated
/Users/koji/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/json-1.8.6/lib/json/common.rb:155: warning: Using the last argument as keyword parameters is deprecated
/Users/koji/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/json-1.8.6/lib/json/common.rb:155: warning: Using the last argument as keyword parameters is deprecated
Uploading to jiikko../Users/koji/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/json-1.8.6/lib/json/common.rb:155: warning: Using the last argument as keyword parameters is deprecated
..../Users/koji/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/json-1.8.6/lib/json/common.rb:155: warning: Using the last argument as keyword parameters is deprecated
done
Name: DeployGateSample
Owner: jiikko
Package: com.deploygate.sample.DeployGateSample
Revision: 35
URL: https://deploygate.com/users/jiikko/platforms/ios/apps/com.deploygate.sample.DeployGateSample
```

## after
```shell
$ USE_LOCAL=1 bundle exec dg deploy deploygate-sample.ipa
/Users/koji/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/faraday_middleware-0.13.1/lib/faraday_middleware/response_middleware.rb:14: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
Uploading to jiikko......done
Name: DeployGateSample
Owner: jiikko
Package: com.deploygate.sample.DeployGateSample
Revision: 32
URL: https://deploygate.com/users/jiikko/platforms/ios/apps/com.deploygate.sample.DeployGateSample
```

You need to upgrade fastlane to stop the warning of faraday_middleware-0.13.1.
However, since the corresponding fastlane has not been released yet, this pull request does not support faraday_middleware.

(faraday_middleware-0.13.1の警告を止めるにはfastlaneをアップグレードする必要がある。
しかし、それに対応したfastlaneはまだリリースされていないので、このプルリクエストではfaraday_middleware(の警告と止めることへ)の対応はしない。)