### PR TITLE
Set HTTPClient timeout

### DIFF
--- a/lib/deploygate/api/v1/base.rb
+++ b/lib/deploygate/api/v1/base.rb
@@ -45,7 +45,11 @@ module DeployGate
         private
 
         def client
-          HTTPClient.new(:agent_name => "dg/#{DeployGate::VERSION}")
+          timeout = 60 * 5 # 5 minutes
+          HTTPClient.new(agent_name: "dg/#{DeployGate::VERSION}").tap do |c|
+            c.receive_timeout = timeout
+            c.send_timeout = timeout
+          end
         end
 
         def headers


### PR DESCRIPTION
HTTPClient's default timeout is 60sec. but 60sec is not enough.

I checked that can upload over 60sec.