### PR TITLE
Fix uninitialized constant DeployGate::VERSION_CODE error

### DIFF
--- a/lib/deploygate.rb
+++ b/lib/deploygate.rb
@@ -36,6 +36,7 @@ require "xcodeproj"
 module DeployGate
 end
 
+require "deploygate/version"
 require "deploygate/raven_ignore_exception"
 require "deploygate/api/v1/base"
 require "deploygate/api/v1/session"
@@ -72,4 +73,3 @@ require "deploygate/xcode/ios"
 require "deploygate/android/gradle_deploy"
 require "deploygate/android/gradle_plugin_installer"
 require "deploygate/android/gradle_project"
-require "deploygate/version"


### PR DESCRIPTION
caused by https://github.com/DeployGate/deploygate-cli/pull/298

## before
```
$ dg deploy
/Users/sota/.rvm/gems/ruby-2.6.9/gems/deploygate-0.8.4/lib/deploygate/api/v1/base.rb:8:in `<class:Base>': uninitialized constant DeployGate::VERSION_CODE (NameError)
```

## after
```
$ dg deploy
[21:41:42]: Resolving Swift Package Manager dependencies...
...
```