### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,7 @@ jobs:
       - run: bundle exec rake build
       - id: gem
         run: echo "::set-output name=result::$(find pkg -name 'deploygate-*.gem' -type f | head -1)"
-      - run:
-        command: |
+      - run: |
           curl --data-binary '@${{ steps.result.outputs.result }}' \
             -H 'Authorization: ${{ secrets.RUBYGEMS_API_KEY }}' \
             "https://rubygems.org/api/v1/gems"


### PR DESCRIPTION
fix "every step must define a `uses` or `run` key" error in "Release built gem on tag-push" workflow

ref: https://github.com/DeployGate/deploygate-cli/actions/runs/3357902022