### PR TITLE
Fix add-devices --server command error

### DIFF
--- a/lib/deploygate/add_devices_server.rb
+++ b/lib/deploygate/add_devices_server.rb
@@ -44,7 +44,7 @@ module DeployGate
       puts HighLine.color(I18n.t('command_builder.add_devices.server.start_build'), HighLine::GREEN)
       pool.perform do
         DeployGate::Commands::AddDevices.register!(devices)
-        DeployGate::Commands::AddDevices.build!(bunlde_id, args, options)
+        DeployGate::Commands::AddDevices.build!(bunlde_id, member_center, args, options)
         puts HighLine.color(I18n.t('command_builder.add_devices.server.finish_build'), HighLine::GREEN)
         puts ''
       end


### PR DESCRIPTION
I fixed add-devices --server command error.
This error maybe occurred from https://github.com/DeployGate/deploygate-cli/pull/270 .

## Before
I ran this command and installed a configuration profile to a device and got the exception.

```
$ dg add-devices --server --distribution-key XXXX
Start add-devices server. Use Ctrl-C to stop.
New device has been added. Start add-devices command.
Device [Name: iPod touch (7 Gen), UDID: xxxx] successfully registered.
Your Workers::Worker exception handler raised an error. Fix your handler!
ArgumentError: wrong number of arguments (given 3, expected 4)
/Users/sota/.rvm/gems/ruby-2.6.9/gems/deploygate-0.8.4/lib/deploygate/commands/add_devices.rb:72:in `build!'
/Users/sota/.rvm/gems/ruby-2.6.9/gems/deploygate-0.8.4/lib/deploygate/add_devices_server.rb:47:in `block in build'
/Users/sota/.rvm/gems/ruby-2.6.9/gems/workers-0.6.1/lib/workers/worker.rb:101:in `perform_handler'
/Users/sota/.rvm/gems/ruby-2.6.9/gems/workers-0.6.1/lib/workers/worker.rb:86:in `event_handler'
/Users/sota/.rvm/gems/ruby-2.6.9/gems/workers-0.6.1/lib/workers/worker.rb:73:in `process_event'
/Users/sota/.rvm/gems/ruby-2.6.9/gems/workers-0.6.1/lib/workers/worker.rb:67:in `start_event_loop'
/Users/sota/.rvm/gems/ruby-2.6.9/gems/workers-0.6.1/lib/workers/worker.rb:13:in `block in initialize'
```

## After
I ran this command and installed a configuration profile to a device and succeed the command.

```
$ dg add-devices --server --distribution-key XXXX
Start add-devices server. Use Ctrl-C to stop.
New device has been added. Start add-devices command.
Device [Name: iPod touch (7 Gen), UDID: xxxx] successfully registered.

+-------------------------------------+---------------------+
|                 Summary for sigh 2.148.1                  |
+-------------------------------------+---------------------+
| adhoc                               | true                |
...
add-devices completed successfully.
```