### PR TITLE
Support disable_notify and message options in add-devices command

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,13 +21,8 @@ en:
       xcodeproj: 'The path to the target Xcode project file (iOS app only)'
     add_devices:
       description: 'Register devices to your Apple Developer account and refresh your provisioning profile. (iOS only) By default, it automatically finds new devices added to your application on DeployGate and ask you which device to register. You can also specify which device to register via command line options.'
-      message: 'Build description message'
-      user: 'Owner user or organization name'
       udid: 'UDID to be registered'
       device_name: 'Device name to be registered'
-      distribution_key: 'If you also want to update distribution page, set the last part of the URL of the page'
-      disable_notify: 'Disable email notification (iOS app only)'
-      xcodeproj: 'The path to the target Xcode project file (iOS app only)'
       server:
         description: 'Start the add-devices server. When added new device automatically run add-devices command.'
         connecting: 'Connecting...'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,7 @@ en:
       udid: 'UDID to be registered'
       device_name: 'Device name to be registered'
       distribution_key: 'If you also want to update distribution page, set the last part of the URL of the page'
+      disable_notify: 'Disable email notification (iOS app only)'
       xcodeproj: 'The path to the target Xcode project file (iOS app only)'
       server:
         description: 'Start the add-devices server. When added new device automatically run add-devices command.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,7 @@ en:
       xcodeproj: 'The path to the target Xcode project file (iOS app only)'
     add_devices:
       description: 'Register devices to your Apple Developer account and refresh your provisioning profile. (iOS only) By default, it automatically finds new devices added to your application on DeployGate and ask you which device to register. You can also specify which device to register via command line options.'
+      message: 'Build description message'
       user: 'Owner user or organization name'
       udid: 'UDID to be registered'
       device_name: 'Device name to be registered'

--- a/lib/deploygate/command_builder.rb
+++ b/lib/deploygate/command_builder.rb
@@ -86,6 +86,7 @@ module DeployGate
       command ADD_DEVICES do |c|
         c.syntax = 'dg add-devices'
         c.description = I18n.t('command_builder.add_devices.description')
+        c.option '--message STRING', String, I18n.t('command_builder.deploy.message')
         c.option '--user STRING', String, I18n.t('command_builder.add_devices.user')
         c.option '--udid STRING', String, I18n.t('command_builder.add_devices.udid')
         c.option '--device-name STRING', String, I18n.t('command_builder.add_devices.device_name')

--- a/lib/deploygate/command_builder.rb
+++ b/lib/deploygate/command_builder.rb
@@ -86,15 +86,15 @@ module DeployGate
       command ADD_DEVICES do |c|
         c.syntax = 'dg add-devices'
         c.description = I18n.t('command_builder.add_devices.description')
-        c.option '--message STRING', String, I18n.t('command_builder.add_devices.message')
-        c.option '--user STRING', String, I18n.t('command_builder.add_devices.user')
+        c.option '--message STRING', String, I18n.t('command_builder.deploy.message')
+        c.option '--user STRING', String, I18n.t('command_builder.deploy.user')
         c.option '--udid STRING', String, I18n.t('command_builder.add_devices.udid')
         c.option '--device-name STRING', String, I18n.t('command_builder.add_devices.device_name')
-        c.option '--distribution-key STRING', String, I18n.t('command_builder.add_devices.distribution_key')
+        c.option '--distribution-key STRING', String, I18n.t('command_builder.deploy.distribution_key')
         c.option '--configuration STRING', String, I18n.t('command_builder.deploy.configuration')
         c.option '--server', I18n.t('command_builder.add_devices.server.description')
-        c.option '--disable_notify', I18n.t('command_builder.add_devices.disable_notify')
-        c.option '--xcodeproj STRING', I18n.t('command_builder.add_devices.xcodeproj')
+        c.option '--disable_notify', I18n.t('command_builder.deploy.disable_notify')
+        c.option '--xcodeproj STRING', I18n.t('command_builder.deploy.xcodeproj')
         c.action do |args, options|
           options.default :user => nil, :server => false, :command => 'add_devices'
           begin

--- a/lib/deploygate/command_builder.rb
+++ b/lib/deploygate/command_builder.rb
@@ -86,14 +86,14 @@ module DeployGate
       command ADD_DEVICES do |c|
         c.syntax = 'dg add-devices'
         c.description = I18n.t('command_builder.add_devices.description')
-        c.option '--message STRING', String, I18n.t('command_builder.deploy.message')
+        c.option '--message STRING', String, I18n.t('command_builder.add_devices.message')
         c.option '--user STRING', String, I18n.t('command_builder.add_devices.user')
         c.option '--udid STRING', String, I18n.t('command_builder.add_devices.udid')
         c.option '--device-name STRING', String, I18n.t('command_builder.add_devices.device_name')
         c.option '--distribution-key STRING', String, I18n.t('command_builder.add_devices.distribution_key')
         c.option '--configuration STRING', String, I18n.t('command_builder.deploy.configuration')
         c.option '--server', I18n.t('command_builder.add_devices.server.description')
-        c.option '--disable_notify', I18n.t('command_builder.deploy.disable_notify')
+        c.option '--disable_notify', I18n.t('command_builder.add_devices.disable_notify')
         c.option '--xcodeproj STRING', I18n.t('command_builder.add_devices.xcodeproj')
         c.action do |args, options|
           options.default :user => nil, :server => false, :command => 'add_devices'

--- a/lib/deploygate/command_builder.rb
+++ b/lib/deploygate/command_builder.rb
@@ -92,6 +92,7 @@ module DeployGate
         c.option '--distribution-key STRING', String, I18n.t('command_builder.add_devices.distribution_key')
         c.option '--configuration STRING', String, I18n.t('command_builder.deploy.configuration')
         c.option '--server', I18n.t('command_builder.add_devices.server.description')
+        c.option '--disable_notify', I18n.t('command_builder.deploy.disable_notify')
         c.option '--xcodeproj STRING', I18n.t('command_builder.add_devices.xcodeproj')
         c.action do |args, options|
           options.default :user => nil, :server => false, :command => 'add_devices'


### PR DESCRIPTION
In addition to dg deploy command, I supported disable_notify and message options in dg add-devices command.

## Checklist
- [x] dg add-devices --disable_notify
    - No email sent
- [x] dg add-devices --message hogehoge
    - Release note changed
- [x] dg add-devices -h