### PR TITLE
Fix not using configuration option in creating provisioning profile

### DIFF
--- a/lib/deploygate/xcode/analyze.rb
+++ b/lib/deploygate/xcode/analyze.rb
@@ -91,7 +91,8 @@ module DeployGate
 
       def resolve_build_configuration(&block)
         gym = Gym::CodeSigningMapping.new(project: @project)
-        specified_configuration = gym.detect_configuration_for_archive
+        specified_configuration = @build_configuration.presence ||
+                                  gym.detect_configuration_for_archive
 
         Xcodeproj::Project.open(@xcodeproj).targets.each do |target|
           target.build_configuration_list.build_configurations.each do |build_configuration|


### PR DESCRIPTION
I fixed not using configuration option in creating provisioning profile.

## When
I had 3 build configrations in the build target.

- Release
    - Bundle ID: net.anoworl.Test
- Debug
    - Bundle ID: net.anoworl.Test
- test
    - Bundle ID: **net.anoworl.Test2** -> I want to build this!


## Before
The app_identifier is **net.anoworl.Test**.

```
$ dg add-devices --configuration test
...
+-------------------------------------+---------------------+
|                 Summary for sigh 2.148.1                  |
+-------------------------------------+---------------------+
| adhoc                               | true                |
| app_identifier                      | net.anoworl.Test    |
...
[04:27:52]: Creating new provisioning profile for 'net.anoworl.Test' with name 'net.anoworl.Test AdHoc' for 'ios' platform
...
```

## After
The app_identifier is **net.anoworl.Test2**.

```
$ dg add-devices --configuration test
+-------------------------------------+---------------------+
|                 Summary for sigh 2.148.1                  |
+-------------------------------------+---------------------+
| adhoc                               | true                |
| app_identifier                      | net.anoworl.Test2   |
...
[10:54:40]: Creating new provisioning profile for 'net.anoworl.Test2' with name 'net.anoworl.Test2 AdHoc' for 'ios' platform
...
```