### PR TITLE
Fix gem push error in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,9 @@ jobs:
       - id: gem
         run: echo "::set-output name=result::$(find pkg -name 'deploygate-*.gem' -type f | head -1)"
       - run: |
-          curl --data-binary '@${{ steps.gem.outputs.result }}' \
-            -H 'Authorization: ${{ secrets.RUBYGEMS_API_KEY }}' \
-            "https://rubygems.org/api/v1/gems"
+          gem push '${{ steps.gem.outputs.result }}'
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
       - uses: slackapi/slack-github-action@v1.16.0
         with:
           payload: "{\"text\": \"Released a deploygate gem in <https://rubygems.org/gems/deploygate/|RubyGems>\"}"


### PR DESCRIPTION
I fixed gem push error in release workflow.

## Before
I ran a release workflow and didn't got error. But the gem wasn't push.
ref: https://github.com/DeployGate/deploygate-cli/actions/runs/3358897357/jobs/5566381106

I execute this command in local and got 400 response without message.

## After
I used "gem push" command and succeed to push gem.