### PR TITLE
The both of 'yes' and 'no' as boolean request parameter are not valid

### DIFF
--- a/lib/deploygate/api/v1/push.rb
+++ b/lib/deploygate/api/v1/push.rb
@@ -24,7 +24,7 @@ module DeployGate
                 { :file => file ,
                   :message => message,
                   :distribution_key => distribution_key,
-                  :disable_notify => disable_notify ? 'yes' : 'no',
+                  :disable_notify => disable_notify,
                   :dg_command => command || '',
                   :env_ci => env_ci
                 }) { process_block.call unless process_block.nil? }


### PR DESCRIPTION
This doesn't mean the format is no longer valid but literally invalid in the first place.