### PR TITLE
Use GITHUB_OUTPUT instead of set-output command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           bundler-cache: true
       - run: bundle exec rake build
       - id: gem
-        run: echo "::set-output name=result::$(find pkg -name 'deploygate-*.gem' -type f | head -1)"
+        run: echo "result=$(find pkg -name 'deploygate-*.gem' -type f | head -1)" >> $GITHUB_OUTPUT
       - run: |
           gem push '${{ steps.gem.outputs.result }}'
         env:


### PR DESCRIPTION
It will fail since June 1st as https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ announced.