### PR TITLE
Update fastlane gem 2.148.1 -> 2.212.1

### DIFF
--- a/deploygate.gemspec
+++ b/deploygate.gemspec
@@ -25,7 +25,7 @@ POST_INSTALL_MESSAGE
   spec.add_runtime_dependency 'commander', '~> 4.4'
   spec.add_runtime_dependency 'plist', '~> 3.1'
   spec.add_runtime_dependency 'xcodeproj', '~> 1.7'
-  spec.add_runtime_dependency 'highline', '~> 1.7'
+  spec.add_runtime_dependency 'highline', '~> 2.0'
   spec.add_runtime_dependency 'uuid', '~> 2.3'
   spec.add_runtime_dependency 'gem_update_checker', '~> 0.2'
   spec.add_runtime_dependency 'activesupport', '~> 4.2'
@@ -35,10 +35,10 @@ POST_INSTALL_MESSAGE
   spec.add_runtime_dependency 'net-ping', '~> 2.0'
   spec.add_runtime_dependency 'socket.io-client-simple', '~> 1.2'
   spec.add_runtime_dependency 'workers', '~> 0.6'
-  spec.add_runtime_dependency 'sentry-raven', '~> 2.8'
+  spec.add_runtime_dependency 'sentry-ruby', '~> 5.8'
 
   # ios build
-  spec.add_runtime_dependency 'fastlane', '~> 2.148.1'
+  spec.add_runtime_dependency 'fastlane', '~> 2.212.1'
 
   spec.add_development_dependency 'bundler', '>= 2.1.4', '< 3.0'
   spec.add_development_dependency 'rake', '~> 12.0'

--- a/lib/deploygate.rb
+++ b/lib/deploygate.rb
@@ -22,7 +22,7 @@ require "webrick"
 require "net/ping"
 require "socket.io-client-simple"
 require "workers"
-require "sentry-raven"
+require "sentry-ruby"
 
 require "i18n"
 I18n.load_path = Dir[File.join(File.dirname(__FILE__), '../config/locales/*.yml')]

--- a/lib/deploygate/command_builder.rb
+++ b/lib/deploygate/command_builder.rb
@@ -16,10 +16,10 @@ module DeployGate
 
     def setup
       # sentry config
-      Raven.configure do |config|
+      Sentry.init do |config|
         config.dsn = 'https://e0b4dda8fe2049a7b0d98c6d2759e067@sentry.io/1371610'
-        config.logger = Raven::Logger.new('/dev/null') # hide sentry log
-        config.excluded_exceptions = Raven::Configuration::IGNORE_DEFAULT + [DeployGate::RavenIgnoreException.name]
+        config.logger = Sentry::Logger.new('/dev/null') # hide sentry log
+        config.excluded_exceptions = Sentry::Configuration::IGNORE_DEFAULT + [DeployGate::RavenIgnoreException.name]
       end
 
       # set Ctrl-C trap
@@ -163,7 +163,7 @@ module DeployGate
         version = Gym::Xcode.xcode_version
         tags[:xcode_version] = version if version.present?
 
-        Raven.capture_exception(error, tags: tags)
+        Sentry.capture_exception(error, tags: tags)
         puts HighLine.color(I18n.t('command_builder.error_handling.thanks'), HighLine::GREEN)
       end
     end


### PR DESCRIPTION
update fastlane gem and dependencies.

reason: I want to apply https://github.com/fastlane/fastlane/pull/21072 .

- [fastlane releases](https://github.com/fastlane/fastlane/releases)
- [fastlane diff](https://github.com/fastlane/fastlane/compare/2.148.1...2.212.1)

## Checklist
- [x] dg login
- [x] dg deploy
- [x] dg add-devices --udid xxx
  - [x] 2FA
- [x] Sentry Error Notification