### PR TITLE
Allow to select a specific workspace

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,7 +18,8 @@ en:
       scheme: 'Set Xcode build scheme (iOS app only)'
       open: 'Open a browser after the build uploaded (OS X only)'
       disable_notify: 'Disable email notification (iOS app only)'
-      xcodeproj: 'The path to the target Xcode project file (iOS app only)'
+      xcodeproj: 'The path to the target .xcodeproj file (iOS app only)'
+      workspace: 'The path to the target .xcworkspace file (iOS app only)'
     add_devices:
       description: 'Register devices to your Apple Developer account and refresh your provisioning profile. (iOS only) By default, it automatically finds new devices added to your application on DeployGate and ask you which device to register. You can also specify which device to register via command line options.'
       udid: 'UDID to be registered'

--- a/lib/deploygate/command_builder.rb
+++ b/lib/deploygate/command_builder.rb
@@ -71,6 +71,7 @@ module DeployGate
         c.option '--open', I18n.t('command_builder.deploy.open')
         c.option '--disable_notify', I18n.t('command_builder.deploy.disable_notify')
         c.option '--xcodeproj STRING', I18n.t('command_builder.deploy.xcodeproj')
+        c.option '--workspace STRING', I18n.t('command_builder.deploy.workspace')
         c.action do |args, options|
           options.default :message => '', :user => nil, :open => false, 'disable_notify' => false, :command => nil
           begin
@@ -95,6 +96,7 @@ module DeployGate
         c.option '--server', I18n.t('command_builder.add_devices.server.description')
         c.option '--disable_notify', I18n.t('command_builder.deploy.disable_notify')
         c.option '--xcodeproj STRING', I18n.t('command_builder.deploy.xcodeproj')
+        c.option '--workspace STRING', I18n.t('command_builder.deploy.workspace')
         c.action do |args, options|
           options.default :user => nil, :server => false, :command => 'add_devices'
           begin

--- a/lib/deploygate/commands/add_devices.rb
+++ b/lib/deploygate/commands/add_devices.rb
@@ -25,12 +25,10 @@ module DeployGate
           distribution_key = options.distribution_key
           server           = options.server
 
-          build_configuration = options.configuration
-          xcodeproj_path = options.xcodeproj
-
           analyze = DeployGate::Xcode::Analyze.new(
-            build_configuration: build_configuration,
-            xcodeproj_path: xcodeproj_path
+            build_configuration: options.configuration,
+            xcodeproj_path: options.xcodeproj,
+            workspace_path: options.workspace
           )
 
           bundle_id = analyze.bundle_identifier

--- a/lib/deploygate/commands/add_devices.rb
+++ b/lib/deploygate/commands/add_devices.rb
@@ -9,6 +9,10 @@ module DeployGate
           work_dir = args.empty? ? Dir.pwd : args.first
           ios_only_command unless DeployGate::Project.ios?(work_dir)
 
+          # Change the current working directory for fastlane else.
+          root_path = DeployGate::Xcode::Ios.project_root_path(work_dir)
+          Dir.chdir(root_path)
+
           session = DeployGate::Session.new
           unless session.login?
             Login.start_login()
@@ -24,12 +28,14 @@ module DeployGate
           build_configuration = options.configuration
           xcodeproj_path = options.xcodeproj
 
-          root_path = DeployGate::Xcode::Ios.project_root_path(work_dir)
-          workspaces = DeployGate::Xcode::Ios.find_workspaces(root_path)
-          analyze = DeployGate::Xcode::Analyze.new(workspaces, build_configuration, nil, xcodeproj_path)
-          bundle_id = analyze.target_bundle_identifier
-          developer_team = analyze.developer_team
-          member_center = DeployGate::Xcode::MemberCenter.new(developer_team)
+          analyze = DeployGate::Xcode::Analyze.new(
+            build_configuration: build_configuration,
+            xcodeproj_path: xcodeproj_path
+          )
+
+          bundle_id = analyze.bundle_identifier
+          export_team_id = analyze.export_team_id
+          member_center = DeployGate::Xcode::MemberCenter.new(export_team_id)
 
           if server
             run_server(session, owner, bundle_id, distribution_key, member_center, args, options)

--- a/lib/deploygate/commands/deploy/build.rb
+++ b/lib/deploygate/commands/deploy/build.rb
@@ -38,10 +38,14 @@ module DeployGate
             analyze = DeployGate::Xcode::Analyze.new(
                 build_configuration: options.configuration,
                 target_scheme: options.scheme,
-                xcodeproj_path: options.xcodeproj
+                xcodeproj_path: options.xcodeproj,
+                workspace_path: options.workspace
             )
 
-            ipa_path = DeployGate::Xcode::Ios.build(ios_analyze: analyze)
+            ipa_path = DeployGate::Xcode::Ios.build(
+              ios_analyze: analyze,
+              allow_provisioning_updates: true
+            )
             Push.upload([ipa_path], options)
           end
 

--- a/lib/deploygate/commands/deploy/build.rb
+++ b/lib/deploygate/commands/deploy/build.rb
@@ -17,9 +17,7 @@ module DeployGate
             options.command = options.command || COMMAND
 
             if DeployGate::Project.ios?(work_dir)
-              root_path = DeployGate::Xcode::Ios.project_root_path(work_dir)
-              workspaces = DeployGate::Xcode::Ios.find_workspaces(root_path)
-              ios(workspaces, options)
+              ios(work_dir, options)
             elsif DeployGate::Project.android?(work_dir)
               DeployGate::Android::GradleDeploy.new(work_dir, options).deploy
             else
@@ -27,37 +25,23 @@ module DeployGate
             end
           end
 
-          # @param [Array] workspaces
+          # @param [String] work_dir
           # @param [Hash] options
           # @return [void]
-          def ios(workspaces, options)
+          def ios(work_dir, options)
             DeployGate::Xcode::Export.check_local_certificates
-            build_configuration = options.configuration
-            target_scheme = options.scheme
-            xcodeproj_path = options.xcodeproj
 
-            analyze = DeployGate::Xcode::Analyze.new(workspaces, build_configuration, target_scheme, xcodeproj_path)
-            target_scheme = analyze.scheme
+            # Change the current working directory for fastlane else.
+            root_path = DeployGate::Xcode::Ios.project_root_path(work_dir)
+            Dir.chdir(root_path)
 
-            code_sign_identity = nil
-            project_profile_info = nil
-            allow_provisioning_updates = true
-            if analyze.code_sign_style == Xcode::Analyze::PROVISIONING_STYLE_MANUAL
-              code_sign_identity = analyze.code_sign_identity
-              project_profile_info = analyze.project_profile_info
-            end
-
-            method = Xcode::Export.method(analyze.target_provisioning_profile) || select_method
-
-            ipa_path = DeployGate::Xcode::Ios.build(
-                analyze,
-                target_scheme,
-                code_sign_identity,
-                project_profile_info,
-                build_configuration,
-                method,
-                allow_provisioning_updates
+            analyze = DeployGate::Xcode::Analyze.new(
+                build_configuration: options.configuration,
+                target_scheme: options.scheme,
+                xcodeproj_path: options.xcodeproj
             )
+
+            ipa_path = DeployGate::Xcode::Ios.build(ios_analyze: analyze)
             Push.upload([ipa_path], options)
           end
 
@@ -81,22 +65,6 @@ module DeployGate
             puts ''
             puts HighLine.color(I18n.t('commands.deploy.build.print_no_install_xcode'), HighLine::YELLOW)
             puts ''
-          end
-
-          def select_method
-            result = nil
-            cli = HighLine.new
-            cli.choose do |menu|
-              menu.prompt = I18n.t('commands.deploy.build.select_method.title')
-              menu.choice(DeployGate::Xcode::Export::AD_HOC) {
-                result = DeployGate::Xcode::Export::AD_HOC
-              }
-              menu.choice(DeployGate::Xcode::Export::ENTERPRISE) {
-                result = DeployGate::Xcode::Export::ENTERPRISE
-              }
-            end
-
-            result
           end
         end
       end

--- a/lib/deploygate/xcode/analyze.rb
+++ b/lib/deploygate/xcode/analyze.rb
@@ -1,150 +1,166 @@
 module DeployGate
   module Xcode
-    class Analyze
-      attr_reader :workspaces, :build_workspace, :scheme, :xcodeproj
 
+    # - xcworkspace can have multiple projects (.xcodeproj)
+    # - xcodeproj can have multiple subprojects (.xcodeproj)
+    #
+    # This means we have to satisfy the following constraints.
+    #
+    # 1. Choose one xcworkspace if multiple workspaces are found. Some of
+    # 2. Choose a proper xcodeproj (root. not subproject)
+    class Analyze
       BASE_WORK_DIR_NAME = 'project.xcworkspace'
       DEFAULT_BUILD_CONFIGURATION = 'Release'
 
       PROVISIONING_STYLE_AUTOMATIC = 'Automatic'
       PROVISIONING_STYLE_MANUAL    = 'Manual'
 
+      CODE_SIGN_STYLE_KEY = "CODE_SIGN_STYLE"
+      CODE_SIGN_IDENTITY_KEY = "CODE_SIGN_IDENTITY"
+      PRODUCT_BUNDLE_IDENTIFIER_KEY = "PRODUCT_BUNDLE_IDENTIFIER"
+      DEVELOPMENT_TEAM_KEY = "DEVELOPMENT_TEAM"
+
       class BundleIdentifierDifferentError < DeployGate::RavenIgnoreException
       end
+      class NotSupportExportMethodError < DeployGate::RavenIgnoreException
+      end
 
-      # @param [Array] workspaces
-      # @param [String] build_configuration
-      # @param [String] target_scheme
+      attr_reader :target_provisioning_profile
+
+      # @param [String, nil] build_configuration
+      # @param [String, nil] target_scheme
+      # @param [String, nil] xcodeproj_path
       # @return [DeployGate::Xcode::Analyze]
-      def initialize(workspaces, build_configuration = nil, target_scheme = nil, xcodeproj_path = nil)
-        @workspaces = workspaces
-        @build_configuration = build_configuration || DEFAULT_BUILD_CONFIGURATION
-        @build_workspace = find_build_workspace(workspaces)
-        @xcodeproj = xcodeproj_path.presence || find_xcodeproj(workspaces)
+      def initialize(
+        xcodeproj_path: nil,
+        workspace_path: nil,
+        build_configuration: nil,
+        target_scheme: nil,
+        export_method: nil,
+        export_team_id: nil
+      )
+        # Don't duplicate this options. This would be modified through fastlane's methods.
+        options = FastlaneCore::Configuration.create(
+          Gym::Options.available_options,
+          {
+            project: xcodeproj_path.presence,
+            workspace: workspace_path.presence,
+            configuration: build_configuration,
+            scheme: target_scheme,
+            export_team_id: export_team_id,
+            export_method: export_method
+          }
+        )
 
-        config = FastlaneCore::Configuration.create(Gym::Options.available_options, { project: @xcodeproj })
-        Gym.config = config
-        @project = FastlaneCore::Project.new(config)
+        # This will detect projects, scheme, configuration and so on. This also throws an error if invalid.
+        # scheme, project/workspace, configuration, export_team_id would be resolved
+        Gym.config = options
 
-        if @project.schemes.length > 1 && target_scheme && @project.schemes.include?(target_scheme)
-          @project.options[:scheme] = target_scheme
-        else
-          @project.select_scheme
+        options[:export_team_id] ||= Gym.project.build_settings[DEVELOPMENT_TEAM_KEY]
+
+        # TODO: Need to support UDID additions for watchOS and App Extension
+
+        if options[:export_method].nil?
+          if (profiles = Gym.config.dig(:export_options, :provisioningProfiles)).present?
+            @target_provisioning_profile = Xcode::Export.provisioning_profile(
+              bundle_identifier,
+              uuid = nil,
+              options[:export_team_id],
+              profiles[bundle_identifier.to_sym]
+            )
+
+            options[:export_method] = Xcode::Export.method(@target_provisioning_profile) || select_export_method
+          end
         end
-        @scheme = @project.options[:scheme]
+
+        Gym.config[:codesigning_identity] = Gym.project.build_settings[CODE_SIGN_IDENTITY_KEY] if code_sign_style == PROVISIONING_STYLE_MANUAL
+      ensure
+        # Run value substitutions again after filling all values
+        Gym.config = Gym.config
+      end
+
+      # @return [String]
+      def scheme
+        fastlane_project.options[:scheme]
+      end
+
+      # @return [String]
+      def xcodeproj_path
+        if fastlane_project.workspace?
+          available_schemes = fastlane_project.workspace.schemes.reject { |_, v| v.include?("Pods/Pods.xcodeproj") }
+          available_schemes[self.scheme]
+        else
+          fastlane_project.path
+        end
+      end
+
+      # @return [String, nil] nil if it's a workspace
+      def workspace_path
+        if fastlane_project.workspace?
+          fastlane_project.options[:workspace]
+        else
+          nil
+        end
+      end
+
+      def build_configuration
+        Gym.detect_configuration_for_archive
+      end
+
+      def export_team_id
+        fastlane_project.options[:export_team_id]
+      end
+
+      def export_method
+        fastlane_project.options[:export_method]
+      end
+
+      def bundle_identifier
+        Gym.project.build_settings[PRODUCT_BUNDLE_IDENTIFIER_KEY]
       end
 
       def code_sign_style
-        style = nil
-        resolve_build_configuration do |build_configuration, target|
-          style = build_configuration.resolve_build_setting("CODE_SIGN_STYLE", target)
-        end
-
-        style
+        Gym.project.build_settings[CODE_SIGN_STYLE_KEY]
       end
 
-      def code_sign_identity
-        identity = nil
-        resolve_build_configuration do |build_configuration, target|
-          identity = build_configuration.resolve_build_setting("CODE_SIGN_IDENTITY", target)
-        end
-
-        identity
-      end
-
-      # TODO: Need to support UDID additions for watchOS and App Extension
-      # @return [String]
-      def target_bundle_identifier
-        bundle_identifier = nil
-        resolve_build_configuration do |build_configuration, target|
-          bundle_identifier = build_configuration.resolve_build_setting("PRODUCT_BUNDLE_IDENTIFIER", target)
-        end
-
-        bundle_identifier
-      end
-
-      def developer_team
-        team = nil
-        resolve_build_configuration do |build_configuration, target|
-          team = build_configuration.resolve_build_setting("DEVELOPMENT_TEAM", target)
-        end
-
-        team
-      end
-
-      def project_profile_info
-        gym = Gym::CodeSigningMapping.new(project: @project)
-
-        {
-            provisioningProfiles: gym.detect_project_profile_mapping
-        }
-      end
-
-      def target_provisioning_profile
-        gym = Gym::CodeSigningMapping.new(project: @project)
-        bundle_id = target_bundle_identifier
-
-        Xcode::Export.provisioning_profile(bundle_id, nil, developer_team, gym.merge_profile_mapping[bundle_id.to_sym])
+      # @return [Hash, FastlaneCore::Configuration]
+      def fastlane_config
+        Gym.config
       end
 
       private
 
-      def resolve_build_configuration(&block)
-        gym = Gym::CodeSigningMapping.new(project: @project)
-        specified_configuration = @build_configuration.presence ||
-                                  gym.detect_configuration_for_archive
-
-        Xcodeproj::Project.open(@xcodeproj).targets.each do |target|
-          target.build_configuration_list.build_configurations.each do |build_configuration|
-            # Used the following code as an example
-            # https://github.com/fastlane/fastlane/blob/2.148.1/gym/lib/gym/code_signing_mapping.rb#L138
-            current = build_configuration.build_settings
-            next if gym.test_target?(current)
-            sdk_root = build_configuration.resolve_build_setting("SDKROOT", target)
-            next unless gym.same_platform?(sdk_root)
-            next unless specified_configuration == build_configuration.name
-
-            # If SKIP_INSTALL is true, it is an app extension or watch app
-            next if current["SKIP_INSTALL"]
-
-            block.call(build_configuration, target)
-          end
+      def select_export_method
+        result = nil
+        cli = HighLine.new
+        cli.choose do |menu|
+          menu.prompt = I18n.t('commands.deploy.build.select_method.title')
+          menu.choice(::DeployGate::Xcode::Export::AD_HOC) {
+            result = ::DeployGate::Xcode::Export::AD_HOC
+          }
+          menu.choice(DeployGate::Xcode::Export::ENTERPRISE) {
+            result = ::DeployGate::Xcode::Export::ENTERPRISE
+          }
         end
+
+        raise NotSupportExportMethodError, "#{result} is not supported" unless ::DeployGate::Xcode::Export::SUPPORT_EXPORT_METHOD.include?(result)
+
+        result
       end
 
-      # @param [Array] workspaces
-      # @return [String]
-      def find_xcodeproj(workspaces)
-        return nil if workspaces.empty?
+      # @return [FastlaneCore::Project]
+      def fastlane_project
+        Gym.project
+      end
 
-        if workspaces.count == 1
-          scheme_workspace = workspaces.first
+      # @return [Xcodeproj::Project]
+      def xcode_project
+        #noinspection RubyMismatchedReturnType
+        if fastlane_project.workspace?
+          Xcodeproj::Project.open(self.xcodeproj_path)
         else
-          scheme_workspace = nil
-          workspaces.each do |workspace|
-            if BASE_WORK_DIR_NAME == File.basename(workspace)
-              scheme_workspace = workspace
-            end
-          end
+          fastlane_project.project
         end
-
-        scheme_workspace != nil ? File.dirname(scheme_workspace) : nil
-      end
-
-      # @param [Array] workspaces
-      # @return [String]
-      def find_build_workspace(workspaces)
-        return nil if workspaces.empty?
-        return workspaces.first if workspaces.count == 1
-
-        select = nil
-        workspaces.each do |workspace|
-          if BASE_WORK_DIR_NAME != File.basename(workspace)
-            select = workspace
-          end
-        end
-
-        select
       end
     end
   end

--- a/lib/deploygate/xcode/ios.rb
+++ b/lib/deploygate/xcode/ios.rb
@@ -5,50 +5,21 @@ module DeployGate
       PROJECT_DIR_EXTNAME = '.xcodeproj'
       IGNORE_DIRS = [ '.git', 'Carthage' ]
 
-      class NotSupportExportMethodError < DeployGate::RavenIgnoreException
-      end
-
       class << self
-        # @param [Analyze] ios_analyze
-        # @param [String] target_scheme
-        # @param [String] codesigning_identity
-        # @param [String] provisioning_profile_info
-        # @param [String] build_configuration
-        # @param [String] export_method
+        # @param [DeployGate::Xcode::Analyze] ios_analyze
         # @param [Boolean] allow_provisioning_updates
         # @return [String]
-        def build(ios_analyze,
-                  target_scheme,
-                  codesigning_identity,
-                  provisioning_profile_info = nil,
-                  build_configuration = nil,
-                  export_method = DeployGate::Xcode::Export::AD_HOC,
-                  allow_provisioning_updates = false)
-          raise NotSupportExportMethodError, 'Not support export' unless DeployGate::Xcode::Export::SUPPORT_EXPORT_METHOD.include?(export_method)
-
-          values = {
-              export_method: export_method,
-              configuration: build_configuration || DeployGate::Xcode::Analyze::DEFAULT_BUILD_CONFIGURATION,
-              scheme: target_scheme
-          }
-
-          if ios_analyze.build_workspace
-            values[:workspace] = ios_analyze.build_workspace
-          else
-            values[:project] = ios_analyze.xcodeproj
-          end
-
-          values[:codesigning_identity] = codesigning_identity if codesigning_identity
+        def build(
+          ios_analyze:,
+          allow_provisioning_updates: true
+        )
           if allow_provisioning_updates
-            values[:xcargs]        = '-allowProvisioningUpdates'
-            values[:export_xcargs] = '-allowProvisioningUpdates'
+            Gym.config[:xcargs]        = '-allowProvisioningUpdates'
+            Gym.config[:export_xcargs] = '-allowProvisioningUpdates'
           end
-          values[:export_options] = provisioning_profile_info if provisioning_profile_info
-
-          v = FastlaneCore::Configuration.create(Gym::Options.available_options, values)
 
           begin
-            absolute_ipa_path = File.expand_path(Gym::Manager.new.work(v))
+            absolute_ipa_path = File.expand_path(Gym::Manager.new.work(ios_analyze.fastlane_config))
           rescue => e
             # TODO: build error handling
             use_xcode_path = `xcode-select -p`

--- a/spec/deploygate/xcode/ios_spec.rb
+++ b/spec/deploygate/xcode/ios_spec.rb
@@ -37,7 +37,7 @@ describe DeployGate::Xcode::Ios do
 
       expect {
         DeployGate::Xcode::Ios.build(AnalyzeMock.new, '', '', nil, '',  'not support export method')
-      }.to raise_error DeployGate::Xcode::Ios::NotSupportExportMethodError
+      }.to raise_error DeployGate::Xcode::Analyze::NotSupportExportMethodError
     end
   end
 


### PR DESCRIPTION
This change includes breaking changes because the current custom detection has been removed and all are delegated to Gym's auto detection. Scheme, build configuration and provisioning profiles can be resolved as the current implementation does, however, this changes asks users to choose a proper one if multiple projects and/or workspaces are found. Project/workspace detection caused many troubles because the detection wasn't chosen with accuracy.

