### PR TITLE
Restrict multi_xml version on Ruby 3.0 or lower

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,5 +18,5 @@ jobs:
         with:
           ruby-version:  ${{ matrix.ruby_version }}
           bundler-cache: true
-      - run: gem update --system
+      - run: gem update --system 3.4.22 # The latest of Ruby 2.x support
       - run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in deploygate.gemspec
 gemspec
+
+if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("3.1.0")
+  gem "multi_xml", "~> 0.6.0"
+end


### PR DESCRIPTION
`multi_xml` is required by `httparty` with the relaxed constraint `>= 0.5.2` so it now includes versions that support Ruby 3.1 or higher.

https://rubygems.org/gems/multi_xml/versions/0.7.0

gemspec is evaluated during the release process so Gemfile is it.