### PR TITLE
Use File#exist? instead of File#exists?

### DIFF
--- a/lib/deploygate/android/gradle_project.rb
+++ b/lib/deploygate/android/gradle_project.rb
@@ -6,7 +6,7 @@ module DeployGate
         # @param [String] dir
         # @return [Boolean]
         def root_dir?(dir)
-          File.exists? File.join(dir, 'settings.gradle')
+          File.exist?(File.join(dir, 'settings.gradle'))
         end
       end
     end


### PR DESCRIPTION
File#exists? has been deprecated for a long time and it has been removed in Ruby 3.2 finally.